### PR TITLE
Feature/components

### DIFF
--- a/client/components/BlogItem.tsx
+++ b/client/components/BlogItem.tsx
@@ -24,7 +24,7 @@ const Title = styled.strong`
 
 const Description = styled.p`
   margin-top: 12px;
-  ${props => props.theme.fonts.title6};
+  ${props => props.theme.fonts.body1Regular};
 `;
 
 const Time = styled.time`

--- a/client/components/BlogItem.tsx
+++ b/client/components/BlogItem.tsx
@@ -10,10 +10,15 @@ interface BlogItemProps {
 }
 
 const Container = styled.div`
-  padding: 20px 0;
-
   & > a {
     display: block;
+    padding: 20px 0;
+
+    &:hover {
+      strong, p {
+        color: ${props => props.theme.colors.primary800};
+      }
+    }
   }
 `;
 

--- a/client/components/KeyVisual.tsx
+++ b/client/components/KeyVisual.tsx
@@ -1,0 +1,14 @@
+import React, { FunctionComponent } from "react";
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  height: 500px;
+  background: url('https://static.wixstatic.com/media/4e0c34_9877d0da66514d878e624e6bd45dafe6~mv2.jpg/v1/fill/w_3000,h_955,al_c,q_90,enc_auto/4e0c34_9877d0da66514d878e624e6bd45dafe6~mv2.jpg') no-repeat 50% 75%;
+  background-size: cover;
+`;
+
+const KeyVisual = () => (
+  <Container />
+);
+
+export default KeyVisual;

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, ReactNode } from "react";
 import styled from "@emotion/styled";
 import Header from "./Header";
+import KeyVisual from './KeyVisual';
 
 interface LayoutProps {
   children: ReactNode;
@@ -19,6 +20,7 @@ const Layout: FunctionComponent<LayoutProps> = ({ children }) => {
     <div>
       <Header />
         <main>
+        <KeyVisual />
           <Inner>
             {children}
           </Inner>

--- a/client/components/Pagination.tsx
+++ b/client/components/Pagination.tsx
@@ -1,0 +1,176 @@
+
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import React, { FunctionComponent } from "react";
+import { jsx, css } from "@emotion/react";
+import styled from "@emotion/styled";
+import Link from "next/link";
+
+interface PaginationProps {
+  prevEnd: boolean,
+  prev: boolean,
+  next: boolean,
+  nextEnd: boolean,
+  pageNumbers?: {
+    href: string,
+    current: boolean,
+  },
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  
+  & > a {
+    display: block;
+    margin: 0 5px;
+    padding: 0 3px;
+    color: ${props => props.theme.colors.grey700};
+    ${props => props.theme.fonts.body1Regular};
+
+    &:hover {
+      color: ${props => props.theme.colors.grey900};
+      font-weight: 700;
+    }
+
+    &[aria-current='current'],
+    &[aria-current='current']:hover {
+      color: ${props => props.theme.colors.primary700};
+      font-weight: 700;
+    }
+  }
+`;
+
+const ButtonArrow = props => (
+  <ButtonArrowCommon
+    type="button"
+    {...props}
+  />
+)
+
+const ButtonArrowCommon = styled.button`
+  &::before,
+  &::after {
+    display: inline-block;
+    width: 9px;
+    height: 9px;
+    margin: 0 auto;
+    border: 1px solid ${props => props.theme.colors.grey700};
+    border-width: 0 0 1px 1px;
+    vertical-align: middle;
+    content: '';
+  }
+
+  &:disabled {
+    &::before,
+    &::after {
+      border-color: ${props => props.theme.colors.grey400};
+    }
+  }
+
+  &::after {
+    margin-left: -5px;
+  }
+
+  &:not(:disabled) {
+    &:hover {
+      &::before,
+      &::after {
+        border-color: ${props => props.theme.colors.grey900};
+        border-width: 0 0 1.5px 1.5px;
+      }
+    }
+  }
+`;
+
+const ButtonNextBox = styled.div`
+  & > button {
+    &::before,
+    &::after {
+      -webkit-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+  }
+`;
+
+const ButtonPrevBox = styled.div`
+  & > button {
+    &::before,
+    &::after {
+      -webkit-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+  }
+`;
+
+const buttonNotEnd = css`
+  &::after {
+    content: none;
+  }
+`;
+
+/*
+* @description
+* tabIndex 순서 - 페이지 넘버, 다음 버튼, 이전 버튼
+*/
+const Pagination: FunctionComponent<PaginationProps> = ({
+  prevEnd,
+  prev,
+  next,
+  nextEnd,
+  pageNumbers,
+}) => {
+  return (
+    <Container aria-label="pagination" role="navigation">
+      <ButtonPrevBox>
+        {/* disabled? 보이지 않게? 분기는 페이징 처리하면서? */}
+        <ButtonArrow
+          disabled={!prevEnd}
+          tabIndex={5}
+          aria-label="처음 페이지"
+        />
+
+        <ButtonArrow
+          css={buttonNotEnd}
+          disabled={!prev}
+          tabIndex={4}
+          aria-label="이전 페이지"
+        />
+      </ButtonPrevBox>
+
+      {pageNumbers.map((data, index) => {
+        return (
+          <Link
+            href={data.href}
+            key={data.href}
+          >
+            <a
+              // onClick={}
+              tabIndex={1}
+              aria-current={data.current ? 'current' : null
+            }>{index + 1}</a>
+          </Link>
+        )
+      })}
+
+      <ButtonNextBox>
+        <ButtonArrow
+          css={buttonNotEnd}
+          disabled={!next}
+          aria-label="다음 페이지"
+          tabIndex={2}
+        />
+
+        <ButtonArrow
+          disabled={!nextEnd}
+          aria-label="마지막 페이지"
+          tabIndex={3}
+        />
+      </ButtonNextBox>
+    </Container>
+  );
+};
+
+export default Pagination;

--- a/client/components/Pagination.tsx
+++ b/client/components/Pagination.tsx
@@ -28,7 +28,7 @@ const Container = styled.div`
     margin: 0 5px;
     padding: 0 3px;
     color: ${props => props.theme.colors.grey700};
-    ${props => props.theme.fonts.body1Regular};
+    ${props => props.theme.fonts.body2Regular};
 
     &:hover {
       color: ${props => props.theme.colors.grey900};

--- a/client/stories/Pagination.stories.tsx
+++ b/client/stories/Pagination.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Pagination from '../components/Pagination';
+
+export default {
+  title: 'Example/Pagination',
+  component: Pagination,
+} as ComponentMeta<typeof Pagination>;
+
+const Template: ComponentStory<typeof Pagination> = (args) => <Pagination {...args} />;
+
+export const component = Template.bind({});
+component.args = {
+  pageNumbers : [
+    { href: '/1', current: true },
+    { href: '/2' },
+    { href: '/3' },
+  ]
+};

--- a/client/styles/theme.tsx
+++ b/client/styles/theme.tsx
@@ -80,28 +80,34 @@ const fonts = {
     letterSpacing: "-0.6px",
     fontSize: "20px",
   },
-  title6: {
+
+  body1Regular: {
     lineHeight: "28px",
     letterSpacing: "-0.6px",
     fontSize: "18px",
   },
-
-  body1Regular: {
+  body1bold: {
+    lineHeight: "28px",
+    letterSpacing: "-0.6px",
+    fontSize: "18px",
+    fontWeight: "700"
+  },
+  body2Regular: {
     lineHeight: "28px",
     letterSpacing: "-0.3px",
     fontSize: "16px",
   },
-  body1bold: {
+  body2bold: {
     lineHeight: "28px",
     letterSpacing: "-0.3px",
     fontSize: "16px",
     fontWeight: "700"
   },
-  body2Regular: {
+  body3Regular: {
     lineHeight: "20px",
     fontSize: "14px",
   },
-  body2bold: {
+  body3bold: {
     lineHeight: "20px",
     fontSize: "14px",
     fontWeight: "700"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -13,7 +13,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "types": [
+      "@emotion/react/types/css-prop"
+    ],
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
#19 

페이지네이션, 키비주얼 컴포넌트 추가
- 키비주얼은 채용페이지에 있는 이미지 임의 적용
<br>


### 정의가 필요한 부분
아래 정의가 필요한 부분 정리 후에 페이징 처리하실 때 같이 해주시면 좋을 것 같습니당:)

- 이전, 다음 버튼 노출 방식
     - 요고는 우선 비활성화 방식으로 해 두었는데 정해지면 수정하면 될 것 같아요
     - 비활성화(disabled) 혹은 미 노출
     결론: 비노출
<br>

- 비활성화 혹은 미 노출 시점
     - 블로그 리스트 10개 초과 시 페이지네이션 노출?
     - 페이지네이션 5개 초과 시 다음 버튼 노출?
     - 다음 버튼 클릭 시 이전 버튼 노출?
     - 처음 리스트, 마지막 리스트 이동 버튼 보이는 시점
#### 결론
- << : 맨처음 으로 이동 후 1번 활성화
- < : 5개 묶음으로 이전 묶음으로 이동 / 이동한 이전 묶음의 첫번째 페이지 활성화
- > : 5개 묶음으로 다음 묶음으로 이동 / 이동한 다음 묶음의 첫번째 페이지 활성화
- >> : 맨 뒤 페이지로 이동
<br>
     


논의에서 제외
 _- 넘어가는 개수
     - 이전, 다음 버튼 누를 때 페이지네이션 몇 개씩 넘어가는지
           - 와디즈는 다음 버튼을 눌러야 보여지고 있는 노출 개수만큼 이동 : https://www.wadiz.kr/web/wboard/newsBoardList/?cPage=7
           - 배민은 다음 리스트 누를 때마다 좌측으로 하나씩 이동 : https://techblog.woowahan.com/_




